### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "libc-test"
+description := "libc testing library from musl."
+gitrepo     := "git://nsz.repo.hu:49100/repo/libc-test"
+homepage    := "http://nsz.repo.hu/git/?p=libc-test;a=blob;f=README;hb=HEAD"
+version     := 18e2849 sha256:efa29b27311bb3ee017d092811005e917607f195417a2580589ea2b569ea13e4 http://nsz.repo.hu/git/?p=libc-test;a=snapshot;h=18e2849;sf=tgz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

