### PR TITLE
patches: Adapt malloc patch to match new test format

### DIFF
--- a/patches/0029-Modify-malloc-brk-fail-to-work-with-uktest.patch
+++ b/patches/0029-Modify-malloc-brk-fail-to-work-with-uktest.patch
@@ -1,15 +1,15 @@
-From bd230adb06c644379f161d34b4625314a09338ff Mon Sep 17 00:00:00 2001
-From: Florin Postolache <florin.postolache80@gmail.com>
-Date: Thu, 27 Oct 2022 18:13:54 +0300
+From a05a9c4df6de009b82f1214b8c808e8dfea35f58 Mon Sep 17 00:00:00 2001
+From: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+Date: Tue, 7 May 2024 16:49:15 +0300
 Subject: [PATCH] Modify malloc-brk-fail to work with uktest
 
-Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>
+Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
 ---
- src/regression/malloc-brk-fail.c | 19 +++++++------------
- 1 file changed, 7 insertions(+), 12 deletions(-)
+ src/regression/malloc-brk-fail.c | 21 +++++++--------------
+ 1 file changed, 7 insertions(+), 14 deletions(-)
 
 diff --git a/src/regression/malloc-brk-fail.c b/src/regression/malloc-brk-fail.c
-index d0ccd35..95179d9 100644
+index 420b000..d4b5d48 100644
 --- a/src/regression/malloc-brk-fail.c
 +++ b/src/regression/malloc-brk-fail.c
 @@ -5,11 +5,11 @@
@@ -27,16 +27,15 @@ index d0ccd35..95179d9 100644
  {
  	void *p;
  	void *q;
-@@ -18,27 +18,22 @@ int main(void)
+@@ -17,26 +17,19 @@ int main(void)
+ 	int r;
  
  	// fill memory, largest mmaped area is [p,p+n)
- 	if (t_vmfill(&p, &n, 1) < 1 || n < 2*65536) {
+-	if (t_vmfill(&p, &n, 1) < 1 || n < 2*65536) {
 -		t_error("vmfill failed\n");
++	if (t_vmfill(&p, &n, 1) < 1 || n < 2*65536)
  		return 1;
- 	}
-+
- 	errno = 0;
- 	T(t_setrlim(RLIMIT_DATA, 0));
+-	}
  
  	// malloc should fail here
  	errno = 0;
@@ -48,8 +47,8 @@ index d0ccd35..95179d9 100644
 +	UK_TEST_EXPECT_NULL(q);
 +	UK_TEST_ASSERT(errno == ENOMEM);
  
- 	// make some space available for mmap
- 	T(munmap((char*)p+65536, 65536));
+ 	// make space available for mmap, but ensure it's not contiguous with brk
+ 	T(munmap((char*)p+65536, n-65536));
  
  	// malloc should succeed now
  	q = malloc(10000);
@@ -60,5 +59,5 @@ index d0ccd35..95179d9 100644
 +	UK_TEST_EXPECT_NOT_NULL(q);
  }
 -- 
-2.25.1
+2.43.0
 


### PR DESCRIPTION
The suite got an update on April 14th and now this patch no longer applies.

Functionality was not changed.